### PR TITLE
Add a mass potential to the scalar wave system

### DIFF
--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -29,6 +29,7 @@
 #include "Evolution/Systems/ScalarWave/EnergyDensity.hpp"
 #include "Evolution/Systems/ScalarWave/Equations.hpp"
 #include "Evolution/Systems/ScalarWave/Initialize.hpp"
+#include "Evolution/Systems/ScalarWave/MassPotential.hpp"
 #include "Evolution/Systems/ScalarWave/MomentumDensity.hpp"
 #include "Evolution/Systems/ScalarWave/System.hpp"
 #include "Evolution/Tags/Filter.hpp"
@@ -153,6 +154,7 @@ struct EvolutionMetavars {
       tmpl::append<typename system::variables_tag::tags_list,
                    typename deriv_compute::type::tags_list, error_tags>,
       ScalarWave::Tags::EnergyDensityCompute<volume_dim>,
+      ScalarWave::Tags::MassPotentialCompute,
       ScalarWave::Tags::MomentumDensityCompute<volume_dim>,
       ScalarWave::Tags::OneIndexConstraintCompute<volume_dim>,
       ScalarWave::Tags::TwoIndexConstraintCompute<volume_dim>,
@@ -306,6 +308,10 @@ struct EvolutionMetavars {
                                           ::ScalarWave::Tags::ConstraintGamma2>,
         evolution::dg::Initialization::ProjectMortars<EvolutionMetavars>,
         evolution::Actions::ProjectRunEventsAndDenseTriggers,
+        ::amr::projectors::CopyFromCreatorOrLeaveAsIs<
+            ScalarWave::Tags::Gamma2Value>,
+        ::amr::projectors::CopyFromCreatorOrLeaveAsIs<
+            ScalarWave::Tags::MassValue>,
         ::amr::projectors::DefaultInitialize<
             Initialization::Tags::InitialTimeDelta,
             Initialization::Tags::InitialSlabSize<local_time_stepping>,

--- a/src/Evolution/Systems/ScalarWave/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarWave/CMakeLists.txt
@@ -12,6 +12,7 @@ spectre_target_sources(
   Constraints.cpp
   EnergyDensity.cpp
   Equations.cpp
+  MassPotential.cpp
   MomentumDensity.cpp
   TimeDerivative.cpp
   VolumeTermsInstantiation.cpp

--- a/src/Evolution/Systems/ScalarWave/Initialize.hpp
+++ b/src/Evolution/Systems/ScalarWave/Initialize.hpp
@@ -33,6 +33,8 @@ namespace Actions {
 template <size_t Dim>
 struct InitializeConstraints {
   using simple_tags = tmpl::list<ScalarWave::Tags::ConstraintGamma2>;
+  using simple_tags_from_options =
+      tmpl::list<ScalarWave::Tags::Gamma2Value, ScalarWave::Tags::MassValue>;
 
   using compute_tags = tmpl::list<>;
 
@@ -46,7 +48,8 @@ struct InitializeConstraints {
       const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {
     const auto& mesh = db::get<domain::Tags::Mesh<Dim>>(box);
-    Scalar<DataVector> gamma_2{mesh.number_of_grid_points(), 0.};
+    Scalar<DataVector> gamma_2{mesh.number_of_grid_points(),
+                               db::get<ScalarWave::Tags::Gamma2Value>(box)};
 
     Initialization::mutate_assign<simple_tags>(make_not_null(&box),
                                                std::move(gamma_2));

--- a/src/Evolution/Systems/ScalarWave/MassPotential.cpp
+++ b/src/Evolution/Systems/ScalarWave/MassPotential.cpp
@@ -22,6 +22,6 @@ Scalar<DataVector> mass_potential(const Scalar<DataVector>& psi,
   mass_potential(make_not_null(&result), psi, mass);
   return result;
 }
-.
+
 }  // namespace ScalarWave
 

--- a/src/Evolution/Systems/ScalarWave/MassPotential.cpp
+++ b/src/Evolution/Systems/ScalarWave/MassPotential.cpp
@@ -22,17 +22,6 @@ Scalar<DataVector> mass_potential(const Scalar<DataVector>& psi,
   mass_potential(make_not_null(&result), psi, mass);
   return result;
 }
-
+.
 }  // namespace ScalarWave
 
-#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
-
-#define INSTANTIATE(_, data)                                                 \
-  void ScalarWave::mass_potential(gsl::not_null<Scalar<DataVector>*> result, \
-                                  const Scalar<DataVector>& psi,             \
-                                  const double& mass);
-
-GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
-
-#undef INSTANTIATE
-#undef DIM

--- a/src/Evolution/Systems/ScalarWave/MassPotential.cpp
+++ b/src/Evolution/Systems/ScalarWave/MassPotential.cpp
@@ -1,0 +1,38 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ScalarWave/MassPotential.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace ScalarWave {
+void mass_potential(gsl::not_null<Scalar<DataVector>*> result,
+                    const Scalar<DataVector>& psi, const double& mass) {
+  get(*result) = square(mass) * get(psi);
+}
+
+Scalar<DataVector> mass_potential(const Scalar<DataVector>& psi,
+                                  const double& mass) {
+  Scalar<DataVector> result{get(psi).size()};
+  mass_potential(make_not_null(&result), psi, mass);
+  return result;
+}
+
+}  // namespace ScalarWave
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                 \
+  void ScalarWave::mass_potential(gsl::not_null<Scalar<DataVector>*> result, \
+                                  const Scalar<DataVector>& psi,             \
+                                  const double& mass);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef INSTANTIATE
+#undef DIM

--- a/src/Evolution/Systems/ScalarWave/MassPotential.hpp
+++ b/src/Evolution/Systems/ScalarWave/MassPotential.hpp
@@ -1,0 +1,54 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/ScalarWave/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace ScalarWave {
+/// @{
+/*!
+ * \brief Computes the mass potential of the scalar wave system.
+ *
+ * Below is the function used to calculate the mass potential.
+ *
+ * \f{align*}
+ * U = m^2 * \psi
+ * \f}
+ */
+void mass_potential(gsl::not_null<Scalar<DataVector>*> result,
+                    const Scalar<DataVector>& psi, const double& mass);
+
+Scalar<DataVector> mass_potential(const Scalar<DataVector>& psi,
+                                  const double& mass);
+/// @}
+
+namespace Tags {
+/// \brief Computes the mass potential using ScalarWave::mass_potential()
+struct MassPotentialCompute : MassPotential, db::ComputeTag {
+  using argument_tags = tmpl::list<Psi, MassValue>;
+
+  using return_type = Scalar<DataVector>;
+
+  static constexpr auto function =
+      static_cast<void (*)(gsl::not_null<Scalar<DataVector>*> result,
+                           const Scalar<DataVector>&, const double&)>(
+          &mass_potential);
+
+  using base = MassPotential;
+};
+}  // namespace Tags
+}  // namespace ScalarWave

--- a/src/Evolution/Systems/ScalarWave/OptionTags.hpp
+++ b/src/Evolution/Systems/ScalarWave/OptionTags.hpp
@@ -1,0 +1,27 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Evolution/Tags.hpp"
+#include "Options/String.hpp"
+
+namespace ScalarWave::OptionTags {
+/// \ingroup OptionTagsGroup
+/// \ingroup TimeGroup
+/// \brief One-index constraint parameter gamma_2
+struct Gamma2 {
+  using type = double;
+  static constexpr Options::String help = {
+      "One-index constraint parameter gamma_2."};
+  static type lower_bound() { return 0.0; }
+  using group = evolution::OptionTags::Group;
+};
+
+struct Mass {
+  using type = double;
+  static constexpr Options::String help = {"Mass of the scalar field"};
+  static type lower_bound() { return 0.0; }
+  using group = evolution::OptionTags::Group;
+};
+}  // namespace ScalarWave::OptionTags

--- a/src/Evolution/Systems/ScalarWave/Tags.hpp
+++ b/src/Evolution/Systems/ScalarWave/Tags.hpp
@@ -12,7 +12,9 @@
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/ScalarWave/OptionTags.hpp"
 #include "Evolution/Systems/ScalarWave/TagsDeclarations.hpp"
+#include "Utilities/TMPL.hpp"
 
 class DataVector;
 
@@ -59,6 +61,25 @@ template <size_t Dim>
 struct OneIndexConstraint : db::SimpleTag {
   using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
 };
+
+/// \brief Tag for gamma_2 as a double
+struct Gamma2Value : db::SimpleTag {
+  using type = double;
+  using option_tags = tmpl::list<ScalarWave::OptionTags::Gamma2>;
+
+  static constexpr bool pass_metavariables = false;
+  static double create_from_options(const double gamma2) { return gamma2; }
+};
+
+/// \brief Tag for mass as a double
+struct MassValue : db::SimpleTag {
+  using type = double;
+  using option_tags = tmpl::list<ScalarWave::OptionTags::Mass>;
+
+  static constexpr bool pass_metavariables = false;
+  static double create_from_options(const double mass) { return mass; }
+};
+
 /*!
  * \brief Tag for the two-index constraint of the ScalarWave system
  *
@@ -109,6 +130,11 @@ struct EvolvedFieldsFromCharacteristicFields : db::SimpleTag {
 /// The energy density of the scalar wave
 template <size_t Dim>
 struct EnergyDensity : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+/// The mass potential of the scalar wave
+struct MassPotential : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 

--- a/src/Evolution/Systems/ScalarWave/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/ScalarWave/TagsDeclarations.hpp
@@ -16,6 +16,8 @@ struct ConstraintGamma2;
 
 template <size_t Dim>
 struct OneIndexConstraint;
+struct Gamma2Value;
+struct MassValue;
 template <size_t Dim>
 struct TwoIndexConstraint;
 
@@ -33,6 +35,7 @@ template <size_t Dim>
 struct EvolvedFieldsFromCharacteristicFields;
 template <size_t Dim>
 struct EnergyDensity;
+struct MassPotential;
 template <size_t Dim>
 struct MomentumDensity;
 }  // namespace ScalarWave::Tags

--- a/src/Evolution/Systems/ScalarWave/TimeDerivative.cpp
+++ b/src/Evolution/Systems/ScalarWave/TimeDerivative.cpp
@@ -4,6 +4,7 @@
 #include "Evolution/Systems/ScalarWave/TimeDerivative.hpp"
 
 #include <cstddef>
+#include <iostream>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -22,9 +23,9 @@ void TimeDerivative<Dim>::apply(
     const tnsr::i<DataVector, Dim, Frame::Inertial>& d_pi,
     const tnsr::ij<DataVector, Dim, Frame::Inertial>& d_phi,
 
-    const Scalar<DataVector>& pi,
+    const Scalar<DataVector>& psi, const Scalar<DataVector>& pi,
     const tnsr::i<DataVector, Dim, Frame::Inertial>& phi,
-    const Scalar<DataVector>& gamma2) {
+    const Scalar<DataVector>& gamma2, const double& mass) {
   // The constraint damping parameter gamma2 is needed for boundary corrections,
   // which means we need it as a temporary tag in order to project it to the
   // boundary. We prevent slicing/projecting directly from the volume to prevent
@@ -39,6 +40,7 @@ void TimeDerivative<Dim>::apply(
   for (size_t d = 1; d < Dim; ++d) {
     get(*dt_pi) -= d_phi.get(d, d);
   }
+  get(*dt_pi) += square(mass) * get(psi);
   for (size_t d = 0; d < Dim; ++d) {
     dt_phi->get(d) = -d_pi.get(d) + get(gamma2) * (d_psi.get(d) - phi.get(d));
   }

--- a/src/Evolution/Systems/ScalarWave/TimeDerivative.cpp
+++ b/src/Evolution/Systems/ScalarWave/TimeDerivative.cpp
@@ -4,7 +4,6 @@
 #include "Evolution/Systems/ScalarWave/TimeDerivative.hpp"
 
 #include <cstddef>
-#include <iostream>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"

--- a/src/Evolution/Systems/ScalarWave/TimeDerivative.hpp
+++ b/src/Evolution/Systems/ScalarWave/TimeDerivative.hpp
@@ -25,8 +25,8 @@ namespace ScalarWave {
 template <size_t Dim>
 struct TimeDerivative {
   using temporary_tags = tmpl::list<Tags::ConstraintGamma2>;
-  using argument_tags =
-      tmpl::list<Tags::Pi, Tags::Phi<Dim>, Tags::ConstraintGamma2>;
+  using argument_tags = tmpl::list<Tags::Psi, Tags::Pi, Tags::Phi<Dim>,
+                                   Tags::ConstraintGamma2, Tags::MassValue>;
 
   static void apply(
       // Time derivatives returned by reference. All the tags in the
@@ -44,8 +44,8 @@ struct TimeDerivative {
       const tnsr::ij<DataVector, Dim, Frame::Inertial>& d_phi,
 
       // Terms list in argument_tags above
-      const Scalar<DataVector>& pi,
+      const Scalar<DataVector>& psi, const Scalar<DataVector>& pi,
       const tnsr::i<DataVector, Dim, Frame::Inertial>& phi,
-      const Scalar<DataVector>& gamma2);
+      const Scalar<DataVector>& gamma2, const double& mass);
 };
 }  // namespace ScalarWave

--- a/src/Evolution/Systems/ScalarWave/VolumeTermsInstantiation.cpp
+++ b/src/Evolution/Systems/ScalarWave/VolumeTermsInstantiation.cpp
@@ -49,9 +49,9 @@ namespace evolution::dg::Actions::detail {
       const std::optional<tnsr::I<DataVector, DIM(data), Frame::Inertial>>&   \
           mesh_velocity,                                                      \
       const std::optional<Scalar<DataVector>>& div_mesh_velocity,             \
-      const Scalar<DataVector>& pi,                                           \
+      const Scalar<DataVector>& psi, const Scalar<DataVector>& pi,            \
       const tnsr::i<DataVector, DIM(data), Frame::Inertial>& phi,             \
-      const Scalar<DataVector>& gamma2);
+      const Scalar<DataVector>& gamma2, const double& mass);
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.cpp
@@ -19,11 +19,13 @@ namespace ScalarWave::Solutions {
 template <size_t Dim>
 PlaneWave<Dim>::PlaneWave(
     std::array<double, Dim> wave_vector, std::array<double, Dim> center,
-    std::unique_ptr<MathFunction<1, Frame::Inertial>> profile)
+    std::unique_ptr<MathFunction<1, Frame::Inertial>> profile,
+    const double mass)
     : wave_vector_(std::move(wave_vector)),
       center_(std::move(center)),
       profile_(std::move(profile)),
-      omega_(magnitude(wave_vector_)) {}
+      mass_(mass),
+      omega_(sqrt(square(magnitude(wave_vector_)) + square(mass_))) {}
 
 template <size_t Dim>
 PlaneWave<Dim>::PlaneWave(const PlaneWave& other)
@@ -31,13 +33,15 @@ PlaneWave<Dim>::PlaneWave(const PlaneWave& other)
       wave_vector_(other.wave_vector_),
       center_(other.center_),
       profile_(other.profile_->get_clone()),
-      omega_(magnitude(wave_vector_)) {}
+      mass_(other.mass_),
+      omega_(other.omega_) {}
 
 template <size_t Dim>
 PlaneWave<Dim>& PlaneWave<Dim>::operator=(const PlaneWave& other) {
   wave_vector_ = other.wave_vector_;
   center_ = other.center_;
-  omega_ = magnitude(wave_vector_);
+  mass_ = other.mass_;
+  omega_ = other.omega_;
   profile_ = other.profile_->get_clone();
   return *this;
 }

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp
@@ -74,7 +74,12 @@ class PlaneWave : public evolution::initial_data::InitialData,
     static constexpr Options::String help = {"The profile of the wave."};
   };
 
-  using options = tmpl::list<WaveVector, Center, Profile>;
+  struct Mass {
+    using type = double;
+    static constexpr Options::String help = {"The mass of the wave."};
+  };
+
+  using options = tmpl::list<WaveVector, Center, Profile, Mass>;
 
   static constexpr Options::String help = {
       "A plane wave solution of the Euclidean wave equation"};
@@ -84,7 +89,8 @@ class PlaneWave : public evolution::initial_data::InitialData,
 
   PlaneWave() = default;
   PlaneWave(std::array<double, Dim> wave_vector, std::array<double, Dim> center,
-            std::unique_ptr<MathFunction<1, Frame::Inertial>> profile);
+            std::unique_ptr<MathFunction<1, Frame::Inertial>> profile,
+            double mass = 0.0);
   PlaneWave(const PlaneWave&);
   PlaneWave& operator=(const PlaneWave&);
   PlaneWave(PlaneWave&&) = default;
@@ -159,6 +165,7 @@ class PlaneWave : public evolution::initial_data::InitialData,
   std::array<double, Dim> wave_vector_{};
   std::array<double, Dim> center_{};
   std::unique_ptr<MathFunction<1, Frame::Inertial>> profile_;
+  double mass_{};
   double omega_{};
 };
 }  // namespace ScalarWave::Solutions

--- a/tests/Unit/Evolution/Systems/ScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ScalarWave/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LIBRARY_SOURCES
   Test_Constraints.cpp
   Test_EnergyDensity.cpp
   Test_Equations.cpp
+  Test_MassPotential.cpp
   Test_MomentumDensity.cpp
   Test_Tags.cpp
   Test_TimeDerivative.cpp

--- a/tests/Unit/Evolution/Systems/ScalarWave/MassPotential.py
+++ b/tests/Unit/Evolution/Systems/ScalarWave/MassPotential.py
@@ -1,0 +1,13 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+# Functions for testing MassPotential.cpp
+
+
+def mass_potential(psi, mass):
+    return mass * mass * psi
+
+
+# End functions for testing MassPotential.cpp

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_MassPotential.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_MassPotential.cpp
@@ -1,0 +1,59 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <random>
+#include <string>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/ScalarWave/MassPotential.hpp"
+#include "Evolution/Systems/ScalarWave/Tags.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+
+namespace {
+template <typename DataType>
+void test_compute_item_in_databox(const DataType& used_for_size) {
+  TestHelpers::db::test_compute_tag<ScalarWave::Tags::MassPotentialCompute>(
+      "MassPotential");
+
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<> dist(-1., 1.);
+
+  const Scalar<DataVector> psi = make_with_random_values<Scalar<DataVector>>(
+      make_not_null(&generator), dist, used_for_size);
+  const double mass = make_with_random_values<double>(make_not_null(&generator),
+                                                      dist, used_for_size);
+
+  const auto box = db::create<
+      db::AddSimpleTags<ScalarWave::Tags::Psi, ScalarWave::Tags::MassValue>,
+      db::AddComputeTags<ScalarWave::Tags::MassPotentialCompute>>(psi, mass);
+
+  const auto expected = ScalarWave::mass_potential(psi, mass);
+
+  CHECK_ITERABLE_APPROX((db::get<ScalarWave::Tags::MassPotential>(box)),
+                        expected);
+}
+
+void test_mass_potential(const DataVector& used_for_size) {
+  void (*f)(const gsl::not_null<Scalar<DataVector>*>, const Scalar<DataVector>&,
+            const double&) = &ScalarWave::mass_potential;
+  pypp::check_with_random_values<1>(f, "MassPotential", {"mass_potential"},
+                                    {{{-1., 1.}}}, used_for_size);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarWave.MassPotential",
+                  "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env(
+      "Evolution/Systems/ScalarWave/");
+
+  const DataVector used_for_size(5);
+  test_mass_potential(used_for_size);
+}

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_Tags.cpp
@@ -32,4 +32,5 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarWave.Tags",
       "EnergyDensity");
   TestHelpers::db::test_simple_tag<ScalarWave::Tags::MomentumDensity<3>>(
       "MomentumDensity");
+  TestHelpers::db::test_simple_tag<ScalarWave::Tags::MassValue>("MassValue");
 }

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_TimeDerivative.cpp
@@ -6,7 +6,6 @@
 #include <algorithm>
 #include <array>
 #include <cstddef>
-#include <iostream>
 #include <memory>
 
 #include "DataStructures/DataBox/DataBox.hpp"


### PR DESCRIPTION
## Proposed changes
Add a mass potential to the scalar wave system. Allow specifying mass and gamma_2 parameters from input file. Add a compute tag to calculate the mass potential.
<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
